### PR TITLE
Preview7 VB [WIP]

### DIFF
--- a/src/tools/r2rdump/DebugInfo.cs
+++ b/src/tools/r2rdump/DebugInfo.cs
@@ -142,7 +142,8 @@ namespace R2RDump
                 case Machine.Arm64:
                     return ((Arm64.Registers)regnum).ToString();
                 default:
-                    throw new NotImplementedException($"No implementation for machine type {machine}.");
+		    return "7777"
+                    //throw new NotImplementedException($"No implementation for machine type {machine}.");
             }
         }
 

--- a/src/tools/r2rdump/DebugInfo.cs
+++ b/src/tools/r2rdump/DebugInfo.cs
@@ -142,7 +142,7 @@ namespace R2RDump
                 case Machine.Arm64:
                     return ((Arm64.Registers)regnum).ToString();
                 default:
-		    return "7777"
+		    return "7777";
                     //throw new NotImplementedException($"No implementation for machine type {machine}.");
             }
         }

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -3394,7 +3394,21 @@ BOOL Module::IsInCurrentVersionBubble()
 
     if (IsReadyToRunCompilation())
     {
-	printf("SIMPLE NAME %s\n", m_pSimpleName);
+	//printf("SIMPLE NAME %s\n", m_pSimpleName);
+	if (strstr(m_pSimpleName,"Xamarin") == nullptr)
+	{
+		printf("EXCLUDING %s\n", m_pSimpleName);
+		return FALSE;
+	}
+
+	if(IsLargeVersionBubbleEnabled())
+	{
+		printf("INCLUDING %s\n", m_pSimpleName);
+	}
+	else
+	{
+		printf("EXCLUDING %s\n", m_pSimpleName);
+	}
         return IsLargeVersionBubbleEnabled();
     }
 

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -3393,7 +3393,10 @@ BOOL Module::IsInCurrentVersionBubble()
         return TRUE;
 
     if (IsReadyToRunCompilation())
+    {
+	printf("SIMPLE NAME %s\n", m_pSimpleName);
         return IsLargeVersionBubbleEnabled();
+    }
 
 #ifdef FEATURE_COMINTEROP
     if (g_fNGenWinMDResilient)

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -1975,19 +1975,40 @@ BOOL CEECompileInfo::NeedsTypeLayoutCheck(CORINFO_CLASS_HANDLE classHnd)
 
     TypeHandle th(classHnd);
 
+    SString name;
+    th.GetName(name);
+    printf("NeedsTypeLayoutCheck(): %S\n", name.GetUnicode());
+
     if (th.IsTypeDesc())
+    {
+	  printf("NO\n");
         return FALSE;
+    }
 
     MethodTable * pMT = th.AsMethodTable();
 
     if (!pMT->IsValueType())
+    {
+	  printf("NO\n");
         return FALSE;
+    }
 
     // Skip this check for equivalent types. Equivalent types are used for interop that ensures
     // matching layout.
     if (pMT->GetClass()->IsEquivalentType())
+    {
+	  printf("NO\n");
         return FALSE;
+    }
 
+    if(!pMT->IsLayoutFixedInCurrentVersionBubble())
+    {
+	  printf("YES\n");
+    }
+    else
+    {
+	  printf("NO\n");
+    }
     return !pMT->IsLayoutFixedInCurrentVersionBubble();
 }
 

--- a/src/vm/zapsig.cpp
+++ b/src/vm/zapsig.cpp
@@ -1242,7 +1242,14 @@ BOOL ZapSig::EncodeMethod(
     TypeHandle ownerType;
 
 #ifdef FEATURE_READYTORUN_COMPILER
-
+    if(IsLargeVersionBubbleEnabled())
+    {
+	printf("Zapsig::EncodeMethod: IsLargeVersionBubbleEnabled\n");
+    }
+    else
+    {
+	printf("Zapsig::EncodeMethod: NOT IsLargeVersionBubbleEnabled\n");
+    }
     // For methods encoded outside of the version bubble, we use pResolvedToken which describes the metadata token from which the method originated
     // For tokens inside the version bubble we are not constrained by the contents of pResolvedToken and as such we skip this codepath
     // Generic interfaces in canonical form are an exception, we need to get the real type from the pResolvedToken so that the lookup at runtime

--- a/src/vm/zapsig.cpp
+++ b/src/vm/zapsig.cpp
@@ -1242,14 +1242,14 @@ BOOL ZapSig::EncodeMethod(
     TypeHandle ownerType;
 
 #ifdef FEATURE_READYTORUN_COMPILER
-    if(IsLargeVersionBubbleEnabled())
+    /*if(IsLargeVersionBubbleEnabled())
     {
 	printf("Zapsig::EncodeMethod: IsLargeVersionBubbleEnabled\n");
     }
     else
     {
 	printf("Zapsig::EncodeMethod: NOT IsLargeVersionBubbleEnabled\n");
-    }
+    }*/
     // For methods encoded outside of the version bubble, we use pResolvedToken which describes the metadata token from which the method originated
     // For tokens inside the version bubble we are not constrained by the contents of pResolvedToken and as such we skip this codepath
     // Generic interfaces in canonical form are an exception, we need to get the real type from the pResolvedToken so that the lookup at runtime

--- a/src/vm/zapsig.cpp
+++ b/src/vm/zapsig.cpp
@@ -152,6 +152,9 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
     }
     CONTRACTL_END
 
+	SString name;
+	handle.GetName(name);
+	printf("%S\n", name.GetUnicode());
     if (handle.IsTypeDesc())
         return GetSignatureForTypeDesc(handle.AsTypeDesc(), pSigBuilder);
 

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -3503,7 +3503,7 @@ unsigned ZapInfo::getClassSize(CORINFO_CLASS_HANDLE cls)
     DWORD size = m_pEEJitInfo->getClassSize(cls);
 
 #ifdef FEATURE_READYTORUN_COMPILER
-    if (IsReadyToRunCompilation())
+    /*if (IsReadyToRunCompilation())
     {
         if (m_pEECompileInfo->NeedsTypeLayoutCheck(cls))
         {
@@ -3512,7 +3512,7 @@ unsigned ZapInfo::getClassSize(CORINFO_CLASS_HANDLE cls)
 
             m_ClassLoadTable.Load(cls, TRUE);
         }
-    }
+    }*/
 #endif
 
     return size;


### PR DESCRIPTION
last commit message:

    crossgen disable checks and instrumentations
    
    there was null poiner dereferencing failure when calling to
    ZapInfo::GetClassSize on
    Enumerator[Xamarin.Forms.XmlnsDefinitionAttribute]
    when crossgening Xamarin.Forms.Xaml.dll (and some other dlls but I have
    stopped on that and it's "fix" resolve the crossgen crash problem at
    all)
    I have disabled that check and crossgen completed "fine" with all dlls.
    
    Applications still are not running due to runtime exception
    "System.BadImageFormatException: an attempt was made to load a program
    with an incorrect format (0x8007000B)"
