### PR TITLE
Smaller bubbles WIP

### DIFF
--- a/src/binder/applicationcontext.cpp
+++ b/src/binder/applicationcontext.cpp
@@ -218,6 +218,19 @@ namespace BINDER_SPACE
         return hr;
     }
 
+    HRESULT ApplicationContext::SetupVersionBubbleAssembliesBindingPaths(SString &sVersionBubbleAssemblies,
+                                                                         BOOL     fAcquireLock)
+    {
+        BINDER_LOG_ENTER(W("ApplicationContext::SetupBindingVersionBubbleAssembliesPaths"));
+        BINDER_LOG_POINTER(W("this"), this);
+#ifndef CROSSGEN_COMPILE
+        CRITSEC_Holder contextLock(fAcquireLock ? GetCriticalSectionCookie() : NULL);
+#endif
+    Exit:
+        BINDER_LOG_LEAVE_HR(W("ApplicationContext::SSetupBindingVersionBubbleAssembliesPaths"), hr);
+        return hr;
+    }
+
     HRESULT ApplicationContext::SetupBindingPaths(SString &sTrustedPlatformAssemblies,
                                                   SString &sPlatformResourceRoots,
                                                   SString &sAppPaths,

--- a/src/binder/clrprivbindercoreclr.cpp
+++ b/src/binder/clrprivbindercoreclr.cpp
@@ -188,6 +188,18 @@ HRESULT CLRPrivBinderCoreCLR::GetBinderID(
     return S_OK;
 }
          
+int CLRPrivBinderCoreCLR::GetVersionBubbleAssembliesListCount()
+{
+	//TODO try-catch
+	return m_appContext.GetVersionBubbleAssembliesListCount();
+}
+
+BOOL CLRPrivBinderCoreCLR::IsAssemblySimpleNameInVersionBubbleList(SString sSimpleName)
+{
+	//TODO try-catch
+	return m_appContext.IsAssemblySimpleNameInVersionBubbleList(sSimpleName);
+}
+
 HRESULT CLRPrivBinderCoreCLR::SetupVersionBubbleAssembliesBindingPaths(SString &sVersionBubbleAssemblies)
 {
     HRESULT hr = S_OK;

--- a/src/binder/clrprivbindercoreclr.cpp
+++ b/src/binder/clrprivbindercoreclr.cpp
@@ -188,6 +188,18 @@ HRESULT CLRPrivBinderCoreCLR::GetBinderID(
     return S_OK;
 }
          
+HRESULT CLRPrivBinderCoreCLR::SetupVersionBubbleAssembliesBindingPaths(SString &sVersionBubbleAssemblies)
+{
+    HRESULT hr = S_OK;
+    
+    EX_TRY
+    {
+        hr = m_appContext.SetupVersionBubbleAssembliesBindingPaths(sVersionBubbleAssemblies,  TRUE /* fAcquireLock */);
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
+
 HRESULT CLRPrivBinderCoreCLR::SetupBindingPaths(SString  &sTrustedPlatformAssemblies,
                                                 SString  &sPlatformResourceRoots,
                                                 SString  &sAppPaths,

--- a/src/binder/inc/applicationcontext.hpp
+++ b/src/binder/inc/applicationcontext.hpp
@@ -120,6 +120,9 @@ namespace BINDER_SPACE
         inline DWORD GetAppDomainId();
         inline void SetAppDomainId(DWORD dwAppDomainId);
 
+        HRESULT ApplicationContext::SetupVersionBubbleAssembliesBindingPaths(/* in */ SString &sVersionBubbleAssemblies,
+                                                                             /* in */ BOOL     fAcquireLock);
+
         HRESULT SetupBindingPaths(/* in */ SString &sTrustedPlatformAssemblies,
                                   /* in */ SString &sPlatformResourceRoots,
                                   /* in */ SString &sAppPaths,
@@ -173,6 +176,8 @@ namespace BINDER_SPACE
 
         SimpleNameToFileNameMap * m_pTrustedPlatformAssemblyMap;
         TpaFileNameHash    * m_pFileNameHash;
+
+	StringArrayList    m_bubblingAssemblies;
     };
 
 #include "applicationcontext.inl"

--- a/src/binder/inc/applicationcontext.hpp
+++ b/src/binder/inc/applicationcontext.hpp
@@ -120,8 +120,10 @@ namespace BINDER_SPACE
         inline DWORD GetAppDomainId();
         inline void SetAppDomainId(DWORD dwAppDomainId);
 
-        HRESULT ApplicationContext::SetupVersionBubbleAssembliesBindingPaths(/* in */ SString &sVersionBubbleAssemblies,
-                                                                             /* in */ BOOL     fAcquireLock);
+        int GetVersionBubbleAssembliesListCount();
+
+        HRESULT SetupVersionBubbleAssembliesBindingPaths(/* in */ SString &sVersionBubbleAssemblies,
+                                                         /* in */ BOOL     fAcquireLock);
 
         HRESULT SetupBindingPaths(/* in */ SString &sTrustedPlatformAssemblies,
                                   /* in */ SString &sPlatformResourceRoots,
@@ -131,6 +133,8 @@ namespace BINDER_SPACE
 
         HRESULT GetAssemblyIdentity(/* in */ LPCSTR                szTextualIdentity,
                                     /* in */ AssemblyIdentityUTF8 **ppAssemblyIdentity);
+
+	BOOL IsAssemblySimpleNameInVersionBubbleList(/* in */SString sSimpleName);
 
         // Getters/Setter
         inline ExecutionContext *GetExecutionContext();
@@ -177,7 +181,7 @@ namespace BINDER_SPACE
         SimpleNameToFileNameMap * m_pTrustedPlatformAssemblyMap;
         TpaFileNameHash    * m_pFileNameHash;
 
-	StringArrayList    m_bubblingAssemblies;
+	StringArrayList    m_versionBubbleAssembliesSimpleNames;
     };
 
 #include "applicationcontext.inl"

--- a/src/binder/inc/clrprivbindercoreclr.h
+++ b/src/binder/inc/clrprivbindercoreclr.h
@@ -33,7 +33,11 @@ public:
 
 public:
 
-    HRESULT SetupBindingPaths::SetupVersionBubbleAssembliesBindingPaths(SString &sVersionBubbleAssemblies);
+    int GetVersionBubbleAssembliesListCount();
+
+    BOOL IsAssemblySimpleNameInVersionBubbleList(/* in */SString sSimpleName);
+
+    HRESULT SetupVersionBubbleAssembliesBindingPaths(SString &sVersionBubbleAssemblies);
 
     HRESULT SetupBindingPaths(SString  &sTrustedPlatformAssemblies,
                               SString  &sPlatformResourceRoots,

--- a/src/binder/inc/clrprivbindercoreclr.h
+++ b/src/binder/inc/clrprivbindercoreclr.h
@@ -33,6 +33,8 @@ public:
 
 public:
 
+    HRESULT SetupBindingPaths::SetupVersionBubbleAssembliesBindingPaths(SString &sVersionBubbleAssemblies);
+
     HRESULT SetupBindingPaths(SString  &sTrustedPlatformAssemblies,
                               SString  &sPlatformResourceRoots,
                               SString  &sAppPaths,

--- a/src/inc/stringarraylist.h
+++ b/src/inc/stringarraylist.h
@@ -16,6 +16,7 @@ class StringArrayList
 {
     ArrayList m_Elements;
 public:
+    StringArrayList(){}
     DWORD GetCount() const;
     SString& operator[] (DWORD idx) const; 
     SString& Get (DWORD idx) const; 
@@ -24,6 +25,8 @@ public:
     void AppendIfNotThere(const SString& string);
 #endif
     ~StringArrayList();
+private:
+    StringArrayList(const StringArrayList&);
 };
 
 

--- a/src/inc/zapper.h
+++ b/src/inc/zapper.h
@@ -348,6 +348,7 @@ class Zapper
 
     void SetPlatformAssembliesPaths(LPCWSTR pwzPlatformAssembliesPaths);
     void SetTrustedPlatformAssemblies(LPCWSTR pwzTrustedPlatformAssemblies);
+    void SetVersionBubbleAssemblies(LPCWSTR pwzVersionBubbleAssemblies);
     void SetPlatformResourceRoots(LPCWSTR pwzPlatformResourceRoots);
     void SetAppPaths(LPCWSTR pwzAppPaths);
     void SetAppNiPaths(LPCWSTR pwzAppNiPaths);

--- a/src/inc/zapper.h
+++ b/src/inc/zapper.h
@@ -118,6 +118,7 @@ class Zapper
     SString                 m_appPaths;
     SString                 m_appNiPaths;
     SString                 m_platformWinmdPaths;
+    SString                 m_versionBubbleAssemblies;
 
 #if !defined(FEATURE_MERGE_JIT_AND_ENGINE)
     SString                 m_CLRJITPath;

--- a/src/tools/r2rdump/DebugInfo.cs
+++ b/src/tools/r2rdump/DebugInfo.cs
@@ -142,7 +142,8 @@ namespace R2RDump
                 case Machine.Arm64:
                     return ((Arm64.Registers)regnum).ToString();
                 default:
-                    throw new NotImplementedException($"No implementation for machine type {machine}.");
+		    return "7777";
+                    //throw new NotImplementedException($"No implementation for machine type {machine}.");
             }
         }
 

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -7153,11 +7153,18 @@ PTR_DomainAssembly AppDomain::FindAssembly(PTR_ICLRPrivAssembly pHostAssembly)
 
 #if !defined(DACCESS_COMPILE) && defined(FEATURE_NATIVE_IMAGE_GENERATION)
 
-void ZapperSetBindingPaths(ICorCompilationDomain *pDomain, SString &trustedPlatformAssemblies, SString &platformResourceRoots, SString &appPaths, SString &appNiPaths)
+void ZapperSetBindingPaths(
+    ICorCompilationDomain *pDomain,
+    SString &trustedPlatformAssemblies,
+    SString &platformResourceRoots,
+    SString &appPaths,
+    SString &appNiPaths,
+    SString &versionBubbleAssemblies)
 {
     CLRPrivBinderCoreCLR *pBinder = static_cast<CLRPrivBinderCoreCLR*>(((CompilationDomain *)pDomain)->GetFusionContext());
     _ASSERTE(pBinder != NULL);
     pBinder->SetupBindingPaths(trustedPlatformAssemblies, platformResourceRoots, appPaths, appNiPaths);
+    pBinder->SetupVersionBubbleAssembliesBindingPaths(versionBubbleAssemblies);
 #ifdef FEATURE_COMINTEROP
     ((CompilationDomain*)pDomain)->SetWinrtApplicationContext(NULL);
 #endif

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -3393,6 +3393,19 @@ BOOL Module::IsInCurrentVersionBubble()
         return TRUE;
 
     if (IsReadyToRunCompilation())
+    {
+        CLRPrivBinderCoreCLR *pBinder= static_cast<CLRPrivBinderCoreCLR*>((pAppDomain->ToCompilationDomain()->GetFusionContext()));
+
+        SString sSimpleName(SString::Utf8, GetAssembly()->GetSimpleName());
+        sSimpleName.Normalize();
+
+        if (pBinder->IsAssemblySimpleNameInVersionBubbleList(sSimpleName))
+        {
+                return true;
+        }
+    }
+
+    if (IsReadyToRunCompilation())
         return IsLargeVersionBubbleEnabled();
 
 #ifdef FEATURE_COMINTEROP

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -672,6 +672,17 @@ bool IsInSameVersionBubble(Assembly * current, Assembly * target)
     if (current == target)
         return true;
 
+    AppDomain *pDomainCurrent = current->GetDomain()->AsAppDomain();
+    CLRPrivBinderCoreCLR *pBinderCurrent = static_cast<CLRPrivBinderCoreCLR*>(((CompilationDomain *)pDomainCurrent)->GetFusionContext());
+
+    SString sSimpleNameTarget(SString::Utf8, target->GetSimpleName());
+    sSimpleNameTarget.Normalize();
+
+    if (pBinderCurrent->IsAssemblySimpleNameInVersionBubbleList(sSimpleNameTarget))
+    {
+	    return true;
+    }
+
     return IsLargeVersionBubbleEnabled();
 }
 
@@ -4631,7 +4642,8 @@ TypeCompareState CEEInfo::compareTypesForCast(
     // always reported back as May, except for CoreLib version bubble.
     if (IsReadyToRunCompilation() && (result == TypeCompareState::MustNot)
         && !GetAppDomain()->ToCompilationDomain()->GetTargetModule()->IsSystem()
-        && !IsLargeVersionBubbleEnabled())
+        && !IsLargeVersionBubbleEnabled()
+	&& ((static_cast<CLRPrivBinderCoreCLR*>(GetAppDomain()->ToCompilationDomain()->GetFusionContext()))->GetVersionBubbleAssembliesListCount() < 2))
     {
         result = TypeCompareState::May;
     }

--- a/src/vm/zapsig.cpp
+++ b/src/vm/zapsig.cpp
@@ -1248,7 +1248,7 @@ BOOL ZapSig::EncodeMethod(
     // Generic interfaces in canonical form are an exception, we need to get the real type from the pResolvedToken so that the lookup at runtime
     // can find the type in interface map.
     // FUTURE: This condition should likely be changed or reevaluated once support for smaller version bubbles is implemented.
-    if (IsReadyToRunCompilation() && (!IsLargeVersionBubbleEnabled() || !pMethod->GetModule()->IsInCurrentVersionBubble() || (pMethod->IsSharedByGenericInstantiations() && pMethod->IsInterface())))
+    if (IsReadyToRunCompilation() && (!pMethod->GetModule()->IsInCurrentVersionBubble() || (pMethod->IsSharedByGenericInstantiations() && pMethod->IsInterface())))
     {
         if (pMethod->IsNDirect())
         {
@@ -1320,7 +1320,7 @@ BOOL ZapSig::EncodeMethod(
     }
 
     // FUTURE: This condition should likely be changed or reevaluated once support for smaller version bubbles is implemented.
-    if (IsReadyToRunCompilation() && (!IsLargeVersionBubbleEnabled() || !pMethod->GetModule()->IsInCurrentVersionBubble()))
+    if (IsReadyToRunCompilation() && (!pMethod->GetModule()->IsInCurrentVersionBubble()))
     {
         Module * pReferencingModule = pMethod->IsNDirect() ?
             pMethod->GetModule() :
@@ -1636,7 +1636,7 @@ void ZapSig::EncodeField(
     DWORD fieldFlags = ENCODE_FIELD_SIG_OwnerType;
 
 #ifdef FEATURE_READYTORUN_COMPILER
-    if (IsReadyToRunCompilation() && (!IsLargeVersionBubbleEnabled() || !pField->GetModule()->IsInCurrentVersionBubble()))
+    if (IsReadyToRunCompilation() && (!pField->GetModule()->IsInCurrentVersionBubble()))
     {
         if (pResolvedToken == NULL)
         {

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -1083,10 +1083,7 @@ HANDLE ZapImage::GenerateFile(LPCWSTR wszOutputFileName, CORCOMPILE_NGEN_SIGNATU
 
 HANDLE ZapImage::SaveImage(LPCWSTR wszOutputFileName, LPCWSTR wszDllPath, CORCOMPILE_NGEN_SIGNATURE * pNativeImageSig)
 {
-    if(!IsReadyToRunCompilation() || IsLargeVersionBubbleEnabled())
-    {
-        OutputManifestMetadata();
-    }
+    OutputManifestMetadata();
 
     OutputTables();
 
@@ -1843,10 +1840,7 @@ void ZapImage::Compile()
         OutputAttributePresenceFilter(m_pMDImport);
         OutputInliningTableForReadyToRun();
         OutputProfileDataForReadyToRun();
-        if (IsLargeVersionBubbleEnabled())
-        {
-            OutputManifestMetadataForReadyToRun();
-        }
+        OutputManifestMetadataForReadyToRun();
     }
     else
 #endif

--- a/src/zap/zapimport.cpp
+++ b/src/zap/zapimport.cpp
@@ -329,7 +329,7 @@ ZapGenericSignature * ZapImportTable::GetGenericSignature(PVOID signature, BOOL 
 /*static*/ DWORD ZapImportTable::EncodeModuleHelper( LPVOID compileContext,
                                                 CORINFO_MODULE_HANDLE referencedModule)
 {
-    _ASSERTE(!IsReadyToRunCompilation() || IsLargeVersionBubbleEnabled());
+    //_ASSERTE(!IsReadyToRunCompilation() || IsLargeVersionBubbleEnabled());
     ZapImportTable * pTable = (ZapImportTable *)compileContext;
     return pTable->GetIndexOfModule(referencedModule);
 }
@@ -953,7 +953,7 @@ void ZapImportTable::EncodeModule(CORCOMPILE_FIXUP_BLOB_KIND kind, CORINFO_MODUL
 {
     if (module != GetImage()->GetModuleHandle())
     {
-        _ASSERTE(!IsReadyToRunCompilation() || IsLargeVersionBubbleEnabled());
+        //_ASSERTE(!IsReadyToRunCompilation() || IsLargeVersionBubbleEnabled());
         pSigBuilder->AppendByte(kind | ENCODE_MODULE_OVERRIDE);
         pSigBuilder->AppendData(GetIndexOfModule(module));
     }

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -3503,7 +3503,7 @@ unsigned ZapInfo::getClassSize(CORINFO_CLASS_HANDLE cls)
     DWORD size = m_pEEJitInfo->getClassSize(cls);
 
 #ifdef FEATURE_READYTORUN_COMPILER
-    if (IsReadyToRunCompilation())
+    if (IsReadyToRunCompilation() && false) //TODO inspect and improve
     {
         if (m_pEECompileInfo->NeedsTypeLayoutCheck(cls))
         {

--- a/src/zap/zapper.cpp
+++ b/src/zap/zapper.cpp
@@ -881,7 +881,13 @@ void Zapper::CreateDependenciesLookupDomainInCurrentDomain()
 }
 
 
-void ZapperSetBindingPaths(ICorCompilationDomain *pDomain, SString &trustedPlatformAssemblies, SString &platformResourceRoots, SString &appPaths, SString &appNiPaths);
+void ZapperSetBindingPaths(
+    ICorCompilationDomain *pDomain,
+    SString &trustedPlatformAssemblies,
+    SString &platformResourceRoots,
+    SString &appPaths,
+    SString &appNiPaths,
+    SString &versionBubbleAssemblies);
 
 void Zapper::CreateCompilationDomain()
 {
@@ -915,7 +921,7 @@ void Zapper::CreateCompilationDomain()
     {
         // TPA-based binding
         // Add the trusted paths and apppath to the binding list
-        ZapperSetBindingPaths(m_pDomain, m_trustedPlatformAssemblies, m_platformResourceRoots, m_appPaths, m_appNiPaths);
+        ZapperSetBindingPaths(m_pDomain, m_trustedPlatformAssemblies, m_platformResourceRoots, m_appPaths, m_appNiPaths, m_versionBubbleAssemblies);
     }
 }
 

--- a/src/zap/zapper.cpp
+++ b/src/zap/zapper.cpp
@@ -33,7 +33,7 @@ static bool s_fNGenNoMetaData;
 // Zapper Object instead of creating one on your own.
 
 
-STDAPI NGenWorker(LPCWSTR pwzFilename, DWORD dwFlags, LPCWSTR pwzPlatformAssembliesPaths, LPCWSTR pwzTrustedPlatformAssemblies, LPCWSTR pwzPlatformResourceRoots, LPCWSTR pwzAppPaths, LPCWSTR pwzOutputFilename=NULL, SIZE_T customBaseAddress=0, LPCWSTR pwzPlatformWinmdPaths=NULL, ICorSvcLogger *pLogger = NULL, LPCWSTR pwszCLRJITPath = nullptr)
+STDAPI NGenWorker(LPCWSTR pwzFilename, DWORD dwFlags, LPCWSTR pwzPlatformAssembliesPaths, LPCWSTR pwzTrustedPlatformAssemblies, LPCWSTR pwzPlatformResourceRoots, LPCWSTR pwzAppPaths, LPCWSTR pwzVersionBubbleAssemblies=NULL, LPCWSTR pwzOutputFilename=NULL, SIZE_T customBaseAddress=0, LPCWSTR pwzPlatformWinmdPaths=NULL, ICorSvcLogger *pLogger = NULL, LPCWSTR pwszCLRJITPath = nullptr)
 {    
     HRESULT hr = S_OK;
 
@@ -90,6 +90,9 @@ STDAPI NGenWorker(LPCWSTR pwzFilename, DWORD dwFlags, LPCWSTR pwzPlatformAssembl
 
         if (pwzTrustedPlatformAssemblies != nullptr)
             zap->SetTrustedPlatformAssemblies(pwzTrustedPlatformAssemblies);
+
+        if (pwzVersionBubbleAssemblies != nullptr)
+            zap->SetVersionBubbleAssemblies(pwzVersionBubbleAssemblies);
 
         if (pwzPlatformResourceRoots != nullptr)
             zap->SetPlatformResourceRoots(pwzPlatformResourceRoots);
@@ -1665,6 +1668,11 @@ void Zapper::SetPlatformAssembliesPaths(LPCWSTR pwzPlatformAssembliesPaths)
 void Zapper::SetTrustedPlatformAssemblies(LPCWSTR pwzTrustedPlatformAssemblies)
 {
     m_trustedPlatformAssemblies.Set(pwzTrustedPlatformAssemblies);
+}
+
+void Zapper::SetVersionBubbleAssemblies(LPCWSTR pwzVersionBubbleAssemblies)
+{
+    m_versionBubbleAssemblies.Set(pwzVersionBubbleAssemblies);
 }
 
 void Zapper::SetPlatformResourceRoots(LPCWSTR pwzPlatformResourceRoots)

--- a/src/zap/zapreadytorun.cpp
+++ b/src/zap/zapreadytorun.cpp
@@ -362,7 +362,7 @@ public:
 /*static*/ DWORD ZapImage::EncodeModuleHelper(LPVOID compileContext,
     CORINFO_MODULE_HANDLE referencedModule)
 {
-    _ASSERTE(!IsReadyToRunCompilation() || IsLargeVersionBubbleEnabled());
+    //_ASSERTE(!IsReadyToRunCompilation() || IsLargeVersionBubbleEnabled());
     ZapImportTable * pTable = (ZapImportTable *)compileContext;
     return pTable->GetIndexOfModule(referencedModule);
 }


### PR DESCRIPTION
A stage in the smaller version bubbles investigation.

Crossgen takes bubbling assemblies and puts them into ApplicationContext structure for further lookup among them.
Global IsInSameVersionBubble(...), Module::IsInCurrentVersionBubble() functions have been updated to provide new logic.
Dozen of conditions used IsLargeVersionBubbleEnabled() have been updated with smaller bubble related logic.
In function ZapInfo::getClassSize turned off actions under condition of crossing version bubble boundaries. In other case compilation falls trying to call a EncodeModuleHelper function pointer previously set to NULL in ZapImportTable::GetCheckTypeLayoutImport(...) function.

Given all this compilation passes, but runtime fails. And R2RDump tool shows that manifest metadata AssemblyRef's contains the same assemblies that it does after Large Version Bubble mode compilation.

Behavior under getClassSize and AssemblyRef content are questions for further investigation.